### PR TITLE
fix: stop removing gnome-system-monitor

### DIFF
--- a/lumina/Containerfile
+++ b/lumina/Containerfile
@@ -41,7 +41,6 @@ RUN rpm-ostree install \
 RUN rpm-ostree override remove \
     gnome-tour \
     gnome-extensions-app \
-    gnome-system-monitor \
     yelp \
   && \
   rm -rf /tmp/* /var/* && \


### PR DESCRIPTION
This is no longer added to the image (or under a new name).  Will check what happens when I rebase.