### PR TITLE
fix: switch from chainguard to ghcr zot image

### DIFF
--- a/lumina/files/usr/etc/containers/systemd/users/zot.container
+++ b/lumina/files/usr/etc/containers/systemd/users/zot.container
@@ -3,7 +3,7 @@ Description=A Zot registry container
 After=network-online.target
 
 [Container]
-Image=cgr.dev/chainguard/zot:latest
+Image=ghcr.io/project-zot/zot-linux-amd64:latest
 ContainerName=zot
 Exec=serve /etc/zot/config.yaml
 Network=eternal.network


### PR DESCRIPTION
The chainguard image does not include the UI as it is minimal.