### PR TITLE
feature: add crun-vm

### DIFF
--- a/lumina/files/_base/usr/etc/containers/containers.conf.d/eternal-runtimes.conf
+++ b/lumina/files/_base/usr/etc/containers/containers.conf.d/eternal-runtimes.conf
@@ -1,0 +1,2 @@
+[engine.runtimes]
+crun-vm = ["/usr/local/bin/crun-vm"]

--- a/lumina/scripts/_base/011-podman-runtimes.sh
+++ b/lumina/scripts/_base/011-podman-runtimes.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+rpm-ostree install crun-vm


### PR DESCRIPTION
In preparation for https://github.com/containers/crun-vm/pull/54, which should allow us to easily create VM-like containers for Bootc images, adding the configuration to the image.  This will hopefully allow us to run something like a VNC server on the container and allow for easy development without waiting on osbuild to output a qcow2 image.
