### PR TITLE
fix: install qemu

### DIFF
--- a/lumina/scripts/_base/005-virt-manager.sh
+++ b/lumina/scripts/_base/005-virt-manager.sh
@@ -3,6 +3,7 @@
 set -euox pipefail
 
 dnf install -y \
+  qemu \
   libvirt \
   edk2-ovmf
 


### PR DESCRIPTION
crun-vm pulled these dependencies previously.  This was removed, so VMs are broken.