### PR TITLE
fix: remove alternatives workaround

### DIFF
--- a/lumina/scripts/_base/009-install-google-chrome.sh
+++ b/lumina/scripts/_base/009-install-google-chrome.sh
@@ -16,9 +16,6 @@ repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-google
 EOF
 
-# Prepare alternatives directory
-mkdir -p /var/lib/alternatives
-
 # Import signing key
 curl --retry 3 --retry-delay 2 --retry-all-errors -sL \
   -o /etc/pki/rpm-gpg/RPM-GPG-KEY-google \


### PR DESCRIPTION
Since upstream has released a new version which makes this no longer required