### PR TITLE
chore: remove anaconda user setup screen

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -41,7 +41,6 @@ on:
         type: choice
         options:
           - amd64
-          - aarch64
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-iso
@@ -79,7 +78,6 @@ jobs:
           - 42-nvidia
         arch:
           - amd64
-          - aarch64
     with:
       image-name: ${{ matrix.image-name }}
       image-registry: ghcr.io/rsturla/eternal-linux

--- a/lumina/iso/configure.sh.tmpl
+++ b/lumina/iso/configure.sh.tmpl
@@ -83,7 +83,14 @@ EOF
 
     cosmic)
         echo "Applying COSMIC-specific configuration..."
-        # TODO: Add COSMIC-specific tweaks here
+        DESKTOP_USER_INTERFACE_SETTINGS=$(cat <<'EOF'
+hidden_spokes =
+    NetworkSpoke
+    PasswordSpoke
+    UserSpoke
+hidden_webui_pages =
+    anaconda-screen-accounts
+EOF
         ;;
 
     budgie|xfce|mate|cinnamon|sway|unknown)

--- a/lumina/iso/configure.sh.tmpl
+++ b/lumina/iso/configure.sh.tmpl
@@ -91,6 +91,7 @@ hidden_spokes =
 hidden_webui_pages =
     anaconda-screen-accounts
 EOF
+)
         ;;
 
     budgie|xfce|mate|cinnamon|sway|unknown)


### PR DESCRIPTION
This can be done after install via cosmic-initial-setup