### PR TITLE
fix: pre-create /usr/local target for 1Password MCP scriptlet

### DIFF
--- a/lumina/scripts/_base/010-install-1password.sh
+++ b/lumina/scripts/_base/010-install-1password.sh
@@ -73,6 +73,19 @@ systemd-sysusers /usr/lib/sysusers.d/onepassword.conf
 systemd-sysusers /usr/lib/sysusers.d/onepassword-cli.conf
 systemd-sysusers /usr/lib/sysusers.d/onepassword-mcp.conf
 
+# The 1Password RPM's %post scriptlet runs `mkdir -p /usr/local/bin` to expose
+# the bundled 1password-mcp binary via /usr/local/bin/1password-mcp. On ostree,
+# /usr/local is a symlink into /var (../var/usrlocal), and during the image
+# build /var is an ephemeral cache mount, so that symlink target does not exist.
+# `mkdir -p` then fails on the dangling /usr/local component with
+# "cannot create directory '/usr/local': File exists", and dnf5 treats the
+# %post failure as fatal, aborting the whole transaction.
+#
+# Pre-create the symlink target so the scriptlet succeeds. The resulting
+# /usr/local/bin/1password-mcp symlink lives under /var and is intentionally not
+# part of the final image: /usr/local is per-machine mutable state on ostree.
+mkdir -p "$(readlink -f /usr/local)/bin"
+
 # Now let's install the packages.
 dnf install -y 1password 1password-cli
 


### PR DESCRIPTION
## Problem

Image builds fail during `dnf install -y 1password 1password-cli` with:

```
>>> Non-critical error in %post scriptlet: 1password-0:8.12.30-1.x86_64
>>> mkdir: cannot create directory '/usr/local': File exists
>>> [RPM] %post(1password-8.12.30-1.x86_64) scriptlet failed, exit status 1
Transaction failed: Rpm transaction failed.
```

## Root cause

1Password 8.12.x added an MCP integration. The RPM's `%post` scriptlet now runs:

```sh
mkdir -p /usr/local/bin
ln -sf /opt/1Password/1password-mcp /usr/local/bin/1password-mcp
```

On ostree, `/usr/local` is a symlink into `/var` (`../var/usrlocal`). During the image build `/var` is mounted as an ephemeral cache (`--mount=type=cache,target=/var`), so the symlink target does not exist. `mkdir -p` then fails on the dangling `/usr/local` component, and dnf5 treats the `%post` failure as fatal, aborting the whole transaction.

## Fix

Pre-create the symlink target before `dnf install` so the scriptlet succeeds:

```sh
mkdir -p "$(readlink -f /usr/local)/bin"
```

The resulting `/usr/local/bin/1password-mcp` symlink lives under `/var` and is intentionally not part of the final image, since `/usr/local` is per-machine mutable state on ostree systems.

## Notes

Upstream has a fix in nightly, but stable (8.12.30) still ships the buggy scriptlet, so this workaround is needed.