### PR TITLE
ci: drop Fedora 43 builds

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        major-version: [43, 44]
+        major-version: [44]
         kernel-flavor: [default]
     secrets: inherit
     with:
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        major-version: [43, 44]
+        major-version: [44]
         kernel-flavor: [default]
     secrets: inherit
     with:
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        major-version: [43, 44]
+        major-version: [44]
         kernel-flavor: [default]
     secrets: inherit
     with:
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        major-version: [43, 44]
+        major-version: [44]
         kernel-flavor: [default]
     secrets: inherit
     with:
@@ -114,7 +114,7 @@ jobs:
   #   strategy:
   #     fail-fast: false
   #     matrix:
-  #       major-version: [43, 44]
+  #       major-version: [44]
   #       kernel-flavor: [default]
   #   secrets: inherit
   #   with:

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -29,11 +29,11 @@ on:
       image-tag:
         description: "The tag to build"
         required: true
-        default: stable
+        default: "44"
         type: choice
         options:
-          - 43
-          - 43-nvidia
+          - 44
+          - 44-nvidia
       arch:
         description: "The architecture to build"
         required: true
@@ -74,8 +74,6 @@ jobs:
           - lumina
           - lumina-cosmic
         image-tag:
-          - 43
-          - 43-nvidia
           - 44
           - 44-nvidia
         arch:


### PR DESCRIPTION
## Summary

Drops Fedora 43 from CI. Fedora 44 becomes the sole build target.

## Changes

- **build-image.yml**: `major-version` matrices `[43, 44]` → `[44]` across all jobs (gnome, gnome-nvidia, cosmic, cosmic-nvidia, and the commented-out kde-nvidia job).
- **build-iso.yml**:
  - `build-all` matrix: removed `43` and `43-nvidia` image-tags.
  - `workflow_dispatch` `image-tag` options: `43`/`43-nvidia` → `44`/`44-nvidia`, default now `"44"`.

## Notes

Branched from latest `main` (`0a33cec`). No other Fedora 43 references found in the repo.